### PR TITLE
Update package version to 4.21.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
   {
 	  "name": "com.nethereum.unity",
 	  "displayName": "Nethereum",
-	  "version": "4.19.2",
+	  "version": "4.21.4",
 	  "unity": "2018.1",
 	  "description": "Nethereum 472 AOT runtime dlls, please check Nethereum releases for more information, extra components, or other versions (net461, net35, netstandard)  https://github.com/Nethereum/Nethereum/releases, example can be found at https://github.com/Nethereum/Unity3dSampleTemplate",
 	  "changelogUrl": "https://github.com/Nethereum/Nethereum/releases",


### PR DESCRIPTION
Hello,

The latest version of the package listed on [OpenUPM](https://openupm.com/packages/com.nethereum.unity/?subPage=versions) is currently 4.19.2. This is due to the package version number not being updated in the package.json file during the last four releases.

This PR updates the version number in package.json to match the correct release version.

After merging this PR, @juanfranblanco will also need to re-push the latest git tag to trigger a new build on OpenUPM.